### PR TITLE
Add CF names to madcp dataset output

### DIFF
--- a/gadcp/io.py
+++ b/gadcp/io.py
@@ -63,9 +63,7 @@ def read_raw_rdi(file, auxillary_only=False):
         "XducerDepth",
     ]
 
-    out = xr.Dataset(
-        data_vars={"dummy": (["z", "time"], np.ones((jj, ii)) * np.nan)}
-    )
+    out = xr.Dataset(data_vars={"dummy": (["z", "time"], np.ones((jj, ii)) * np.nan)})
 
     # get 1d variables
     for v in varsii:
@@ -147,7 +145,7 @@ def read_raw_rdi_uh(file, auxillary_only=False):
     return radcp
 
 
-def extract_raw_rdi(file, i0, i1, outfile, inst='wh'):
+def extract_raw_rdi(file, i0, i1, outfile, inst="wh"):
     """Extract ping range from raw RDI file and save to new raw file.
 
     Parameters
@@ -208,3 +206,64 @@ def _is_number(s):
         return True
     except ValueError:
         return False
+
+
+def cf_conventions():
+    """Return dictionary with CF standard names and units.
+
+    See https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html
+    and http://cfconventions.org/cf-conventions/cf-conventions.html
+    for further information.
+
+    Returns
+    -------
+    CF : dict
+        CF standard names in units.
+    """
+
+    CF = dict(
+        depth=dict(
+            long_name="depth",
+            standard_name="depth",
+            units="m",
+            positive="down",
+        ),
+        u=dict(
+            long_name="u", standard_name="eastward_sea_water_velocity", units="m s-1"
+        ),
+        v=dict(
+            long_name="v", standard_name="northward_sea_water_velocity", units="m s-1"
+        ),
+        w=dict(long_name="w", standard_name="upward_sea_water_velocity", units="m s-1"),
+        e=dict(
+            long_name="error velocity",
+            standard_name="indicative_error_from_multibeam_acoustic_doppler_velocity_profiler_in_sea_water",
+            units="m s-1",
+        ),
+        pressure=dict(
+            long_name="pressure", standard_name="sea_water_pressure", units="dbar"
+        ),
+        temperature=dict(
+            long_name="temperature",
+            standard_name="sea_water_temperature",
+            units="degrees_Celsius",
+        ),
+        xducer_depth=dict(
+            long_name="transducer depth",
+            standard_name="transducer_depth",
+            units="m",
+            positive="down",
+        ),
+        npings=dict(
+            long_name="number of pings",
+            standard_name="number_of_pings",
+        ),
+        pg=dict(
+            long_name="percent good",
+            standard_name="percent_good_pings_in_ensemble_average",
+        ),
+        amp=dict(
+            long_name="amplitude",
+        ),
+    )
+    return CF

--- a/gadcp/madcp.py
+++ b/gadcp/madcp.py
@@ -1245,13 +1245,18 @@ class ProcessADCP:
         # Drop depth levels with all nan
         out = out.dropna(how="all", dim="z")
 
+        # Drop pressure_std and pressure_max
+        dropvars = ['pressure_std', 'pressure_max']
+        for var in dropvars:
+            out = out.drop(var)
+
         # add variable names and units for plotting
         out = self._add_names_and_units(out)
 
         self.ds = out
 
     def _add_names_and_units(self, ds):
-        """Add variable meta-data to Dataset.
+        """Add variable attributes based on CF conventions.
 
         Parameters
         ----------
@@ -1262,14 +1267,10 @@ class ProcessADCP:
         ds : xarray.Dataset
 
         """
-
-        ds.u.attrs = dict(long_name="u", units="m/s")
-        ds.v.attrs = dict(long_name="v", units="m/s")
-        ds.w.attrs = dict(long_name="w", units="m/s")
-        ds.e.attrs = dict(long_name="error velocity", units="m/s")
-        ds.z.attrs = dict(long_name="depth", units="m")
-        ds.temperature.attrs = dict(long_name="temperature", units="°C")
-        ds.pressure.attrs = dict(long_name="pressure", units="dbar")
+        CF = io.cf_conventions()
+        for v in ds.variables:
+            if v in CF:
+                ds[v].attrs = CF[v]
         return ds
 
     def _add_meta_data_to_ds(self):


### PR DESCRIPTION
A first stab at assigning CF-compliant variable names to output (#16).
- Define CF standards in `io.cf_conventions()`.
- Assign to dataset variables in `madcp`.
- Remove `pressure_std` and `pressure_max` from dataset output.

Still to do:
- [ ] Apply to raw data output in `adcp.py`.
- [ ] Decide on CF names for standard deviations (or remove from output).
- [ ] Change `z` to `depth` (#24).